### PR TITLE
Export the `initializeRuntime()` function and allow string runtime names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,8 @@ export {
 	InvokeResult,
 	runtimes,
 	providers,
-	funCacheDir
+	funCacheDir,
+	initializeRuntime
 };
 
 // Environment variable names that AWS Lambda does not allow to be overridden.

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -57,6 +57,7 @@ export default class NativeProvider implements Provider {
 
 	async createProcess(): Promise<ChildProcess> {
 		const { runtime, params, region, version, extractedDir } = this.lambda;
+		const binDir = join(runtime.cacheDir, 'bin');
 		const bootstrap = join(runtime.cacheDir, 'bootstrap');
 
 		const server = new RuntimeServer(this.lambda);
@@ -77,7 +78,7 @@ export default class NativeProvider implements Provider {
 		// https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html
 		const env = {
 			// Non-reserved env vars (can overwrite with params)
-			PATH: process.env.PATH,
+			PATH: `${binDir}:${process.env.PATH}`,
 			LANG: 'en_US.UTF-8',
 
 			// User env vars

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,9 +2,10 @@ import { basename, join } from 'path';
 import { tmpdir } from 'os';
 import * as execa from 'execa';
 import * as assert from 'assert';
-import { mkdirp, remove, readdir, readFile } from 'fs-extra';
+import { mkdirp, remove, readdir, readFile, stat } from 'fs-extra';
 import {
 	funCacheDir,
+	initializeRuntime,
 	cleanCacheDir,
 	createFunction,
 	ValidationError
@@ -144,6 +145,25 @@ export const test_reserved_env = async () => {
 		err.toString(),
 		'ValidationError: The following environment variables can not be configured: AWS_REGION, TZ'
 	);
+};
+
+// Initialization
+export const test_initialize_runtime_with_string = async () => {
+	const runtime = await initializeRuntime('nodejs8.10');
+	assert.equal(typeof runtime.cacheDir, 'string');
+	const nodeStat = await stat(join(runtime.cacheDir, 'bin/node'));
+	assert(nodeStat.isFile());
+};
+
+export const test_initialize_runtime_with_invalid_name = async () => {
+	let err: Error;
+	try {
+		await initializeRuntime('node8.10');
+	} catch (_err) {
+		err = _err;
+	}
+	assert(err);
+	assert.equal('Could not find runtime with name "node8.10"', err.message);
 };
 
 // Invocation


### PR DESCRIPTION
This will be used by `now dev` to launch the builders in a forked child process using the same version of `node` that is used by builders in production, but not actually be a `fun` lambda function.

Also adds the `${cacheDir}/bin` of the runtime to the `PATH` env var in the fun function so that it has access to the binaries provided there by default.