### PR TITLE
Add `6mb` response limit

### DIFF
--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -130,7 +130,7 @@ export class RuntimeServer extends Server {
 		const payload: InvokeResult = {
 			StatusCode: statusCode,
 			ExecutedVersion: '$LATEST',
-			Payload: await text(req)
+			Payload: await text(req, { limit: '6mb' })
 		};
 
 		res.statusCode = 202;
@@ -148,7 +148,7 @@ export class RuntimeServer extends Server {
 			StatusCode: statusCode,
 			FunctionError: 'Handled',
 			ExecutedVersion: '$LATEST',
-			Payload: await text(req)
+			Payload: await text(req, { limit: '6mb' })
 		};
 
 		res.statusCode = 202;
@@ -166,7 +166,7 @@ export class RuntimeServer extends Server {
 			StatusCode: statusCode,
 			FunctionError: 'Unhandled',
 			ExecutedVersion: '$LATEST',
-			Payload: await text(req)
+			Payload: await text(req, { limit: '6mb' })
 		};
 
 		res.statusCode = 202;


### PR DESCRIPTION
Instead of the default `1mb` limit. This matches AWS Lambda's "Invocation Payload" response limit documented at https://docs.aws.amazon.com/lambda/latest/dg/limits.html

Related to: https://spectrum.chat/zeit/now/error-body-exceeded-1mb-limit~69845eac-55c7-412e-b4e5-deba469cfe26