### PR TITLE
 Allow passing AccessKeyId and SecretAccessKey in params

### DIFF
--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -91,6 +91,8 @@ export default class NativeProvider implements Provider {
 			// Restricted env vars
 			_HANDLER: params.Handler,
 			AWS_REGION: region,
+			AWS_ACCESS_KEY_ID: params.AccessKeyId,
+			AWS_SECRET_ACCESS_KEY: params.SecretAccessKey,
 			AWS_DEFAULT_REGION: region,
 			AWS_EXECUTION_ENV: `AWS_Lambda_${params.Runtime}`,
 			AWS_LAMBDA_FUNCTION_NAME: functionName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,8 @@ export interface LambdaParams {
 	Environment?: { Variables: object };
 	MemorySize?: number; // The amount of memory that your function has access to. Increasing the function's memory also increases it's CPU allocation. The default value is 128 MB. The value must be a multiple of 64 MB.
 	Region?: string; // AWS Region name (used for generating the fake ARN, etc.)
+	AccessKeyId?: string; // AWS_ACCESS_KEY_ID environment variable (used by AWS SDK for authentication)
+	SecretAccessKey?: string; // AWS_SECRET_ACCESS_KEY environment variable (used by AWS SDK for authentication)
 	Timeout?: number; // The amount of time that Lambda allows a function to run before terminating it. The default is 3 seconds. The maximum allowed value is 900 seconds.
 }
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -260,7 +260,9 @@ export const test_env_vars = testInvoke(
 				Directory: __dirname + '/functions/nodejs-env'
 			},
 			Handler: 'index.env',
-			Runtime: 'nodejs'
+			Runtime: 'nodejs',
+			AccessKeyId: 'TestAccessKeyId',
+			SecretAccessKey: 'TestSecretAccessKey'
 		}),
 	async fn => {
 		const res = await fn.invoke();
@@ -275,6 +277,8 @@ export const test_env_vars = testInvoke(
 		assert.equal(env.AWS_EXECUTION_ENV, 'AWS_Lambda_nodejs');
 		assert.equal(env.AWS_LAMBDA_FUNCTION_NAME, 'nodejs-env');
 		assert.equal(env.AWS_LAMBDA_FUNCTION_MEMORY_SIZE, '128');
+		assert.equal(env.AWS_ACCESS_KEY_ID, 'TestAccessKeyId');
+		assert.equal(env.AWS_SECRET_ACCESS_KEY, 'TestSecretAccessKey');
 	}
 );
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "lib": ["esnext", "dom"]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
LambdaParams.Environment.Variables checks for "allowed variables" and prevents
users from setting AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. This makes
sense as Lambda also prevents setting these through the API.

Setting them is useful however to replicate the actual deployment environment,
meaning you don't have to pass these manually to the AWS SDK when running
locally with a conditional check.

Never sure how to do these dependent PRs.... I'll delete the other one.