### PR TITLE
Enable `esModuleInterop` option for TypeScript config

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "async-listen": "1.0.0",
-    "cache-or-tmp-directory": "1.0.0",
     "debug": "4.1.1",
     "execa": "1.0.0",
     "fs-extra": "7.0.1",
@@ -37,6 +36,7 @@
     "tar": "4.4.8",
     "uid-promise": "1.0.0",
     "uuid": "3.3.2",
+    "xdg-app-paths": "5.1.0",
     "yauzl-promise": "2.1.3"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 import createDebug from 'debug';
 import { remove } from 'fs-extra';
 import { basename } from 'path';
-import * as listen from 'async-listen';
+import listen from 'async-listen';
 import { unzipToTemp } from './unzip';
 import { LambdaError } from './errors';
 import * as providers from './providers';

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,8 +1,8 @@
-import * as ms from 'ms';
-import * as uuid from 'uuid/v4';
+import ms from 'ms';
+import uuid from 'uuid/v4';
 import createDebug from 'debug';
 import { AddressInfo } from 'net';
-import * as listen from 'async-listen';
+import listen from 'async-listen';
 import { Pool, createPool } from 'generic-pool';
 import { delimiter, basename, join, resolve } from 'path';
 import { ChildProcess, spawn } from 'child_process';

--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -1,9 +1,9 @@
-import * as uuid from 'uuid/v4';
+import uuid from 'uuid/v4';
 import { parse } from 'url';
 import { Server } from 'http';
 import createDebug from 'debug';
 import { run, text } from 'micro';
-import * as createPathMatch from 'path-match';
+import createPathMatch from 'path-match';
 
 import { once } from './once';
 import { createDeferred, Deferred } from './deferred';

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import createDebug from 'debug';
+import XDGAppPaths from 'xdg-app-paths';
 import { createHash, Hash } from 'crypto';
-import * as cachedir from 'cache-or-tmp-directory';
 import { lstat, mkdirp, readdir, remove, readFile, writeFile } from 'fs-extra';
 
 import { Runtime } from './types';
@@ -26,7 +26,7 @@ interface RuntimeImpl {
 
 export const runtimes: Runtimes = {};
 
-export const funCacheDir = cachedir('co.zeit.fun');
+export const funCacheDir = XDGAppPaths('co.zeit.fun').cache();
 
 function createRuntime(
 	runtimes: Runtimes,

--- a/src/runtimes/go1.x/index.ts
+++ b/src/runtimes/go1.x/index.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import * as execa from 'execa';
+import execa from 'execa';
 import createDebug from 'debug';
 import { Runtime } from '../../types';
 import { copyFile, mkdirp, remove } from 'fs-extra';

--- a/src/runtimes/nodejs/bootstrap.ts
+++ b/src/runtimes/nodejs/bootstrap.ts
@@ -1,7 +1,7 @@
 /**
  * Credit: https://github.com/lambci/node-custom-lambda/blob/master/v10.x/bootstrap.js
  */
-import * as http from 'http';
+import http from 'http';
 
 interface LambdaEvent {}
 

--- a/src/unzip.ts
+++ b/src/unzip.ts
@@ -1,10 +1,10 @@
 import { tmpdir } from 'os';
-import * as Mode from 'stat-mode';
+import Mode from 'stat-mode';
 import pipe from 'promisepipe';
 import createDebug from 'debug';
 import { dirname, basename, join } from 'path';
 import { createWriteStream, mkdirp, symlink, unlink } from 'fs-extra';
-import * as streamToPromise from 'stream-to-promise';
+import streamToPromise from 'stream-to-promise';
 import {
 	Entry,
 	ZipFile,
@@ -45,13 +45,23 @@ const getMode = (entry: Entry) =>
 
 interface UnzipOptions {
 	strip?: number;
-};
+}
 
-export async function unzip(zipFile: ZipFile, dir: string, opts: UnzipOptions = {}): Promise<void> {
+export async function unzip(
+	zipFile: ZipFile,
+	dir: string,
+	opts: UnzipOptions = {}
+): Promise<void> {
 	let entry: Entry;
 	const strip = opts.strip || 0;
 	while ((entry = await zipFile.readEntry()) !== null) {
-		const fileName = strip === 0 ? entry.fileName : entry.fileName.split('/').slice(strip).join('/');
+		const fileName =
+			strip === 0
+				? entry.fileName
+				: entry.fileName
+						.split('/')
+						.slice(strip)
+						.join('/');
 		const destPath = join(dir, fileName);
 		if (/\/$/.test(entry.fileName)) {
 			debug('Creating directory %o', destPath);

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,7 +1,7 @@
 import { basename, join } from 'path';
 import { tmpdir } from 'os';
-import * as execa from 'execa';
-import * as assert from 'assert';
+import execa from 'execa';
+import assert from 'assert';
 import { mkdirp, remove, readdir, readFile, stat } from 'fs-extra';
 import {
 	funCacheDir,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
+    "esModuleInterop": true,
     "module": "commonjs",
     "outDir": "dist",
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,20 +470,6 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
-cache-directory@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cache-directory/-/cache-directory-2.0.0.tgz#0d8efa1abbb6d1dd926d255ce733b4f7c5ab2892"
-  integrity sha512-7YKEapH+2Uikde8hySyfobXBqPKULDyHNl/lhKm7cKf/GJFdG/tU/WpLrOg2y9aUrQrWUilYqawFIiGJPS6gDA==
-  dependencies:
-    xdg-basedir "^3.0.0"
-
-cache-or-tmp-directory@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/cache-or-tmp-directory/-/cache-or-tmp-directory-1.0.0.tgz#07834b808f250a307cc77991dc757eca869d8c29"
-  integrity sha512-EuGx1xcSEpPSI2YgivZNvbCgCepc4hyAAFgDO1FRuZ/BYrgnZR4NIQFrcHhawyXxXv/yAtk9ck47qB0Pfhzg8Q==
-  dependencies:
-    cache-directory "^2.0.0"
-
 caching-transform@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-3.0.1.tgz#1df89e850803ad15f68dafb2abe9a8b866016c7d"
@@ -3635,10 +3621,17 @@ write-file-atomic@^2.3.0:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
 
-xdg-basedir@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
-  integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+xdg-app-paths@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/xdg-app-paths/-/xdg-app-paths-5.1.0.tgz#f52f724f91e88244148c085c09bcd396443d8cae"
+  integrity sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==
+  dependencies:
+    xdg-portable "^7.0.0"
+
+xdg-portable@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/xdg-portable/-/xdg-portable-7.1.0.tgz#0b44ed91808262bdb1eac2155692b8e52e453cca"
+  integrity sha512-QBi9hgiacopF0dMgBKO9Josh52YiBw6Chf0AqqMfc96go6EJqNBImFTws7NHIsWX2rWBlEzHC1I+pABYcYM9RQ==
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Also updates config dir logic to use `xdg-app-paths` module instead of `cache-or-tmp-directory` module, for consistency with the `now` repo.