### PR TITLE
Add support for system installed `python3` runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ implemented are:
  * `nodejs10.x` for Node.js Lambda functions using a downloaded Node v10.15.3 binary
  * `python` for Python Lambda functions using the system `python` binary
  * `python2.7` for Python Lambda functions using a downloaded Python v2.7.12 binary
+ * `python3` for Python Lambda functions using the system `python3` binary (or fallback to `python`)
  * `python3.6` for Python Lambda functions using a downloaded Python v3.6.8 binary
  * `python3.7` for Python Lambda functions using a downloaded Python v3.7.2 binary
  * `go1.x` for Lambda functions written in Go - binary must be compiled for your platform

--- a/src/runtimes.ts
+++ b/src/runtimes.ts
@@ -10,6 +10,7 @@ import * as nodejs6 from './runtimes/nodejs6.10';
 import * as nodejs8 from './runtimes/nodejs8.10';
 import * as nodejs10 from './runtimes/nodejs10.x';
 import * as python27 from './runtimes/python2.7';
+import * as python3 from './runtimes/python3';
 import * as python36 from './runtimes/python3.6';
 import * as python37 from './runtimes/python3.7';
 
@@ -49,6 +50,7 @@ createRuntime(runtimes, 'nodejs8.10', nodejs8);
 createRuntime(runtimes, 'nodejs10.x', nodejs10);
 createRuntime(runtimes, 'python');
 createRuntime(runtimes, 'python2.7', python27);
+createRuntime(runtimes, 'python3', python3);
 createRuntime(runtimes, 'python3.6', python36);
 createRuntime(runtimes, 'python3.7', python37);
 

--- a/src/runtimes/python/bootstrap
+++ b/src/runtimes/python/bootstrap
@@ -1,10 +1,17 @@
 #!/bin/bash
 set -euo pipefail
 
+PYTHONBIN="$( which python3 || which python || echo '' )"
+
+if [ -z "$PYTHONBIN"  ]; then
+    echo "Please install Python"
+	exit 1
+fi
+
 # `PYTHONPATH` is *not* a restricted env var, so only set the
 # default one if the user did not provide one of their own
 if [ -z "${PYTHONPATH-}" ]; then
 	export PYTHONPATH="$LAMBDA_RUNTIME_DIR"
 fi
 
-exec python "$LAMBDA_RUNTIME_DIR/bootstrap.py"
+exec "$PYTHONBIN" "$LAMBDA_RUNTIME_DIR/bootstrap.py"

--- a/src/runtimes/python/bootstrap
+++ b/src/runtimes/python/bootstrap
@@ -1,17 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-PYTHONBIN="$( which python3 || which python || echo '' )"
-
-if [ -z "$PYTHONBIN"  ]; then
-    echo "Please install Python"
-	exit 1
-fi
-
 # `PYTHONPATH` is *not* a restricted env var, so only set the
 # default one if the user did not provide one of their own
 if [ -z "${PYTHONPATH-}" ]; then
 	export PYTHONPATH="$LAMBDA_RUNTIME_DIR"
 fi
 
-exec "$PYTHONBIN" "$LAMBDA_RUNTIME_DIR/bootstrap.py"
+exec python "$LAMBDA_RUNTIME_DIR/bootstrap.py"

--- a/src/runtimes/python/bootstrap.ts
+++ b/src/runtimes/python/bootstrap.ts
@@ -7,5 +7,21 @@ if (!process.env.PYTHONPATH) {
 	process.env.PYTHONPATH = process.env.LAMBDA_RUNTIME_DIR;
 }
 
-const bootstrap = join(__dirname, 'bootstrap.py');
-spawn('python', [ bootstrap ], { stdio: 'inherit' });
+let pythonBin = 'python3';
+const fallback = () => {
+	pythonBin = 'python';
+};
+const child = spawn(pythonBin, ['--version']);
+child.on('error', fallback);
+child.stderr.on('data', fallback);
+child.stdout.on('data', (data?: string) => {
+	const isPython3 =
+		data && data.toString() && data.toString().startsWith('Python 3');
+
+	if (!isPython3) {
+		fallback();
+	}
+
+	const bootstrap = join(__dirname, 'bootstrap.py');
+	spawn(pythonBin, [bootstrap], { stdio: 'inherit' });
+});

--- a/src/runtimes/python/bootstrap.ts
+++ b/src/runtimes/python/bootstrap.ts
@@ -7,21 +7,5 @@ if (!process.env.PYTHONPATH) {
 	process.env.PYTHONPATH = process.env.LAMBDA_RUNTIME_DIR;
 }
 
-let pythonBin = 'python3';
-const fallback = () => {
-	pythonBin = 'python';
-};
-const child = spawn(pythonBin, ['--version']);
-child.on('error', fallback);
-child.stderr.on('data', fallback);
-child.stdout.on('data', (data?: string) => {
-	const isPython3 =
-		data && data.toString() && data.toString().startsWith('Python 3');
-
-	if (!isPython3) {
-		fallback();
-	}
-
-	const bootstrap = join(__dirname, 'bootstrap.py');
-	spawn(pythonBin, [bootstrap], { stdio: 'inherit' });
-});
+const bootstrap = join(__dirname, 'bootstrap.py');
+spawn('python', [bootstrap], { stdio: 'inherit' });

--- a/src/runtimes/python3/bootstrap
+++ b/src/runtimes/python3/bootstrap
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# Use the system installed python3
+PYTHONBIN="$( command -v python3 || command -v python || echo '' )"
+if [ -z "$PYTHONBIN"  ]; then
+    echo "Please install Python 3"
+    exit 1
+fi
+
+# Execute the "python" runtime bootstrap
+export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../python >/dev/null 2>&1 && pwd )"
+exec "$PYTHONBIN" "$LAMBDA_RUNTIME_DIR/bootstrap.py" "$@"

--- a/src/runtimes/python3/bootstrap
+++ b/src/runtimes/python3/bootstrap
@@ -8,6 +8,13 @@ if [ -z "$PYTHONBIN"  ]; then
     exit 1
 fi
 
+# Check if python version is 3
+PYTHONVERSION="$( "$PYTHONBIN" --version 2>&1 )"
+case $PYTHONVERSION in
+  "Python 3"*) ;;
+  *) echo "Please install Python 3" && exit 1 ;;
+esac
+
 # Execute the "python" runtime bootstrap
 export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../python"
 exec "$PYTHONBIN" "$LAMBDA_RUNTIME_DIR/bootstrap.py" "$@"

--- a/src/runtimes/python3/bootstrap
+++ b/src/runtimes/python3/bootstrap
@@ -10,7 +10,7 @@ fi
 
 # Check if python version is 3
 PYTHONVERSION="$( "$PYTHONBIN" --version 2>&1 )"
-case $PYTHONVERSION in
+case "$PYTHONVERSION" in
   "Python 3"*) ;;
   *) echo "Please install Python 3" && exit 1 ;;
 esac

--- a/src/runtimes/python3/bootstrap
+++ b/src/runtimes/python3/bootstrap
@@ -9,5 +9,5 @@ if [ -z "$PYTHONBIN"  ]; then
 fi
 
 # Execute the "python" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../python >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../python"
 exec "$PYTHONBIN" "$LAMBDA_RUNTIME_DIR/bootstrap.py" "$@"

--- a/src/runtimes/python3/bootstrap.ts
+++ b/src/runtimes/python3/bootstrap.ts
@@ -1,0 +1,27 @@
+import { join } from 'path';
+import { spawn } from 'child_process';
+
+// `PYTHONPATH` is *not* a restricted env var, so only set the
+// default one if the user did not provide one of their own
+if (!process.env.PYTHONPATH) {
+	process.env.PYTHONPATH = process.env.LAMBDA_RUNTIME_DIR;
+}
+
+let pythonBin = 'python3';
+const fallback = () => {
+	pythonBin = 'python';
+};
+const child = spawn(pythonBin, ['--version']);
+child.on('error', fallback);
+child.stderr.on('data', fallback);
+child.stdout.on('data', (data?: string) => {
+	const isPython3 =
+		data && data.toString() && data.toString().startsWith('Python 3');
+
+	if (!isPython3) {
+		fallback();
+	}
+
+	const bootstrap = join(__dirname, '..', 'python', 'bootstrap.py');
+	spawn(pythonBin, [bootstrap], { stdio: 'inherit' });
+});

--- a/src/runtimes/python3/bootstrap.ts
+++ b/src/runtimes/python3/bootstrap.ts
@@ -8,12 +8,10 @@ if (!process.env.PYTHONPATH) {
 }
 
 let pythonBin = 'python3';
-const fallback = () => {
+function fallback() {
 	pythonBin = 'python';
-};
-const child = spawn(pythonBin, ['--version']);
-child.on('error', fallback);
-child.stderr.on('data', (data?: string) => {
+}
+function handler(data?: string) {
 	const isPython3 =
 		data && data.toString() && data.toString().startsWith('Python 3');
 
@@ -23,4 +21,8 @@ child.stderr.on('data', (data?: string) => {
 
 	const bootstrap = join(__dirname, '..', 'python', 'bootstrap.py');
 	spawn(pythonBin, [bootstrap], { stdio: 'inherit' });
-});
+}
+const child = spawn(pythonBin, ['--version']);
+child.on('error', fallback);
+child.stderr.on('data', handler);
+child.stdout.on('data', handler);

--- a/src/runtimes/python3/bootstrap.ts
+++ b/src/runtimes/python3/bootstrap.ts
@@ -11,9 +11,9 @@ let pythonBin = 'python3';
 const fallback = () => {
 	pythonBin = 'python';
 };
-const child = spawn(pythonBin, ['--version', '2>&1']);
+const child = spawn(pythonBin, ['--version']);
 child.on('error', fallback);
-child.stdout.on('data', (data?: string) => {
+child.stderr.on('data', (data?: string) => {
 	const isPython3 =
 		data && data.toString() && data.toString().startsWith('Python 3');
 

--- a/src/runtimes/python3/bootstrap.ts
+++ b/src/runtimes/python3/bootstrap.ts
@@ -11,9 +11,8 @@ let pythonBin = 'python3';
 const fallback = () => {
 	pythonBin = 'python';
 };
-const child = spawn(pythonBin, ['--version']);
+const child = spawn(pythonBin, ['--version', '2>&1']);
 child.on('error', fallback);
-child.stderr.on('data', fallback);
 child.stdout.on('data', (data?: string) => {
 	const isPython3 =
 		data && data.toString() && data.toString().startsWith('Python 3');

--- a/src/runtimes/python3/index.ts
+++ b/src/runtimes/python3/index.ts
@@ -2,5 +2,5 @@ import { Runtime } from '../../types';
 import { runtimes, initializeRuntime } from '../../runtimes';
 
 export async function init(_runtime: Runtime): Promise<void> {
-	await Promise.all([initializeRuntime(runtimes.python)]);
+	await initializeRuntime(runtimes.python);
 }

--- a/src/runtimes/python3/index.ts
+++ b/src/runtimes/python3/index.ts
@@ -1,0 +1,6 @@
+import { Runtime } from '../../types';
+import { runtimes, initializeRuntime } from '../../runtimes';
+
+export async function init(_runtime: Runtime): Promise<void> {
+	await Promise.all([initializeRuntime(runtimes.python)]);
+}

--- a/test/test.ts
+++ b/test/test.ts
@@ -533,6 +533,22 @@ export const test_python27_version = testInvoke(
 	}
 );
 
+// `python3` runtime
+export const test_python3_version = testInvoke(
+	() =>
+		createFunction({
+			Code: {
+				Directory: __dirname + '/functions/python-version'
+			},
+			Handler: 'handler.handler',
+			Runtime: 'python3'
+		}),
+	async fn => {
+		const payload = await fn();
+		assert.equal(payload['platform.python_version'][0], '3');
+	}
+);
+
 // `python3.6` runtime
 export const test_python36_version = testInvoke(
 	() =>


### PR DESCRIPTION
This PR adds a new runtime for `python3` that uses the system's python installation and then fallback to `python`.

Related to

- https://github.com/zeit/now/issues/2495
- https://github.com/zeit/now/issues/2849
- https://github.com/zeit/now/issues/2860