### PR TITLE
Remove `-o pipefail` option from bootstrap for POSIX compliance

### DIFF
--- a/src/runtimes/nodejs/bootstrap
+++ b/src/runtimes/nodejs/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Credit: https://github.com/lambci/node-custom-lambda/blob/master/v10.x/bootstrap
 

--- a/src/runtimes/nodejs10.x/bootstrap
+++ b/src/runtimes/nodejs10.x/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "nodejs" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../nodejs >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../nodejs"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"

--- a/src/runtimes/nodejs10.x/bootstrap
+++ b/src/runtimes/nodejs10.x/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Node.js version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/nodejs6.10/bootstrap
+++ b/src/runtimes/nodejs6.10/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "nodejs" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../nodejs >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../nodejs"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"

--- a/src/runtimes/nodejs6.10/bootstrap
+++ b/src/runtimes/nodejs6.10/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Node.js version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/nodejs8.10/bootstrap
+++ b/src/runtimes/nodejs8.10/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "nodejs" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../nodejs >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../nodejs"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"

--- a/src/runtimes/nodejs8.10/bootstrap
+++ b/src/runtimes/nodejs8.10/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Node.js version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/python/bootstrap
+++ b/src/runtimes/python/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # `PYTHONPATH` is *not* a restricted env var, so only set the
 # default one if the user did not provide one of their own

--- a/src/runtimes/python2.7/bootstrap
+++ b/src/runtimes/python2.7/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Python version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/python2.7/bootstrap
+++ b/src/runtimes/python2.7/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "python" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../python >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../python"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"

--- a/src/runtimes/python3.6/bootstrap
+++ b/src/runtimes/python3.6/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Python version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/python3.6/bootstrap
+++ b/src/runtimes/python3.6/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "python" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../python >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../python"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"

--- a/src/runtimes/python3.7/bootstrap
+++ b/src/runtimes/python3.7/bootstrap
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 # Ensure the downloaded Python version is used
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"

--- a/src/runtimes/python3.7/bootstrap
+++ b/src/runtimes/python3.7/bootstrap
@@ -5,5 +5,5 @@ set -eu
 export PATH="$LAMBDA_RUNTIME_DIR/bin:$PATH"
 
 # Execute the "python" runtime bootstrap
-export LAMBDA_RUNTIME_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")"/../python >/dev/null 2>&1 && pwd )"
+export LAMBDA_RUNTIME_DIR="$(dirname "$0")/../python"
 exec "$LAMBDA_RUNTIME_DIR/bootstrap" "$@"


### PR DESCRIPTION
So that POSIX `/bin/sh` may be used instead of Bash, for platforms that do not have Bash installed by default (i.e. Alpine Linux).