### PR TITLE
Add `nodejs-reference-error` test case

### DIFF
--- a/test/functions/nodejs-exit/handler.js
+++ b/test/functions/nodejs-exit/handler.js
@@ -1,7 +1,0 @@
-exports.handler = ({ exit }, context) => {
-	if (exit) {
-		process.exit(1);
-	} else {
-		return { hi: true};
-	}
-};

--- a/test/functions/nodejs-reference-error/handler.js
+++ b/test/functions/nodejs-reference-error/handler.js
@@ -1,0 +1,4 @@
+// This will cause the lambda process to exit upon bootup
+x + 1;
+
+exports.handler = () => ({ foo: 'bar' });

--- a/test/test.ts
+++ b/test/test.ts
@@ -446,6 +446,28 @@ export const test_nodejs810_handled_error = testInvoke(
 	}
 );
 
+export const test_nodejs_reference_error = testInvoke(
+	() =>
+		createFunction({
+			Code: {
+				Directory: __dirname + '/functions/nodejs-reference-error'
+			},
+			Handler: 'handler.handler',
+			Runtime: 'nodejs'
+		}),
+	async fn => {
+		let err;
+		try {
+			await fn();
+		} catch (_err) {
+			err = _err;
+		}
+		assert(err);
+		assert.equal(err.name, 'ReferenceError');
+		assert.equal(err.message, 'x is not defined');
+	}
+);
+
 export const test_nodejs810_exit_in_handler = testInvoke(
 	() =>
 		createFunction({


### PR DESCRIPTION
Ensures that the `invoke()` function returns quickly with the expected error message when a Node.js `ReferenceError` occurs in the lambda code.