### PR TITLE
Fix `invoke()` resolving upon lambda initialization error

### DIFF
--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -193,9 +193,10 @@ export class RuntimeServer extends Server {
 	}
 
 	close(callback?: Function): this {
-		if (this.resultDeferred) {
+		const deferred = this.initDeferred || this.resultDeferred;
+		if (deferred) {
 			const statusCode = 200;
-			this.resultDeferred.resolve({
+			deferred.resolve({
 				StatusCode: statusCode,
 				FunctionError: 'Unhandled',
 				ExecutedVersion: '$LATEST',

--- a/test/functions/nodejs-exit/handler.js
+++ b/test/functions/nodejs-exit/handler.js
@@ -1,0 +1,1 @@
+process.exit(1);

--- a/test/test.ts
+++ b/test/test.ts
@@ -347,6 +347,29 @@ export const test_lambda_invoke = testInvoke(
 	}
 );
 
+export const test_nodejs_exit_before_init = testInvoke(
+	() =>
+		createFunction({
+			Code: {
+				Directory: __dirname + '/functions/nodejs-exit'
+			},
+			Handler: 'handler.handler',
+			Runtime: 'nodejs'
+		}),
+	async fn => {
+		let err;
+		try {
+			await fn();
+		} catch (_err) {
+			err = _err;
+		}
+		assert(err);
+		assert(
+			err.message.includes('Process exited before completing request')
+		);
+	}
+);
+
 // `fun` should be resilient to its runtime cache being wiped away during
 // runtime. At least, in between function creations. Consider a user running
 // `now dev cache clean` while a `now dev` server is running, and then the


### PR DESCRIPTION
Before, the `invoke()` function would never resolve. Now it properly throws an error.