### PR TITLE
Calculate the `RequestId` earlier

### DIFF
--- a/src/runtime-server.ts
+++ b/src/runtime-server.ts
@@ -43,7 +43,7 @@ export class RuntimeServer extends Server {
 		this.nextDeferred = createDeferred<void>();
 		this.invokeDeferred = null;
 		this.resultDeferred = null;
-		this.currentRequestId = null;
+		this.currentRequestId = uuid();
 	}
 
 	async serve(req, res): Promise<any> {
@@ -107,14 +107,12 @@ export class RuntimeServer extends Server {
 		debug('Waiting for the `invoke()` function to be called');
 		req.setTimeout(0); // disable default 2 minute socket timeout
 		const params = await this.invokeDeferred.promise;
-		const requestId = uuid();
-		this.currentRequestId = requestId;
 
 		// TODO: use dynamic values from lambda params
 		const deadline = 5000;
 		const functionArn =
 			'arn:aws:lambda:us-west-1:977805900156:function:nate-dump';
-		res.setHeader('Lambda-Runtime-Aws-Request-Id', requestId);
+		res.setHeader('Lambda-Runtime-Aws-Request-Id', this.currentRequestId);
 		res.setHeader('Lambda-Runtime-Invoked-Function-Arn', functionArn);
 		res.setHeader('Lambda-Runtime-Deadline-Ms', String(deadline));
 		const finish = once(res, 'finish');

--- a/src/runtimes/nodejs6.10/bootstrap.ts
+++ b/src/runtimes/nodejs6.10/bootstrap.ts
@@ -3,4 +3,4 @@ import { spawn } from 'child_process';
 
 const nodeBin = join(__dirname, 'bin', 'node');
 const bootstrap = join(__dirname, '..', 'nodejs', 'bootstrap.js');
-spawn(nodeBin, [ bootstrap ], { stdio: 'inherit' });
+spawn(nodeBin, [bootstrap], { stdio: 'inherit' });

--- a/src/runtimes/nodejs8.10/bootstrap.ts
+++ b/src/runtimes/nodejs8.10/bootstrap.ts
@@ -3,4 +3,4 @@ import { spawn } from 'child_process';
 
 const nodeBin = join(__dirname, 'bin', 'node');
 const bootstrap = join(__dirname, '..', 'nodejs', 'bootstrap.js');
-spawn(nodeBin, [ bootstrap ], { stdio: 'inherit' });
+spawn(nodeBin, [bootstrap], { stdio: 'inherit' });

--- a/src/runtimes/python2.7/bootstrap.ts
+++ b/src/runtimes/python2.7/bootstrap.ts
@@ -3,4 +3,4 @@ import { spawn } from 'child_process';
 
 const pythonBin = join(__dirname, 'bin', 'python');
 const bootstrap = join(__dirname, '..', 'python', 'bootstrap.py');
-spawn(pythonBin, [ bootstrap ], { stdio: 'inherit' });
+spawn(pythonBin, [bootstrap], { stdio: 'inherit' });

--- a/src/runtimes/python3.6/bootstrap.ts
+++ b/src/runtimes/python3.6/bootstrap.ts
@@ -3,4 +3,4 @@ import { spawn } from 'child_process';
 
 const pythonBin = join(__dirname, 'bin', 'python');
 const bootstrap = join(__dirname, '..', 'python', 'bootstrap.py');
-spawn(pythonBin, [ bootstrap ], { stdio: 'inherit' });
+spawn(pythonBin, [bootstrap], { stdio: 'inherit' });

--- a/src/runtimes/python3.7/bootstrap.ts
+++ b/src/runtimes/python3.7/bootstrap.ts
@@ -3,4 +3,4 @@ import { spawn } from 'child_process';
 
 const pythonBin = join(__dirname, 'bin', 'python');
 const bootstrap = join(__dirname, '..', 'python', 'bootstrap.py');
-spawn(pythonBin, [ bootstrap ], { stdio: 'inherit' });
+spawn(pythonBin, [bootstrap], { stdio: 'inherit' });

--- a/test/test.ts
+++ b/test/test.ts
@@ -16,6 +16,16 @@ import { LambdaError } from '../src/errors';
 
 const isWin = process.platform === 'win32';
 
+function assertProcessExitedError(err: Error): void {
+	assert(err instanceof LambdaError);
+	assert.equal(err.name, 'LambdaError');
+	assert(
+		/RequestId: [a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12} Process exited before completing request/.test(
+			err.message
+		)
+	);
+}
+
 export function test_funCacheDir() {
 	assert.equal('string', typeof funCacheDir);
 }
@@ -364,9 +374,7 @@ export const test_nodejs_exit_before_init = testInvoke(
 			err = _err;
 		}
 		assert(err);
-		assert(
-			err.message.includes('Process exited before completing request')
-		);
+		assertProcessExitedError(err);
 	}
 );
 
@@ -508,9 +516,7 @@ export const test_nodejs810_exit_in_handler = testInvoke(
 			err = _err;
 		}
 		assert(err);
-		assert(
-			err.message.includes('Process exited before completing request')
-		);
+		assertProcessExitedError(err);
 	}
 );
 


### PR DESCRIPTION
This is so that the runtime initialization error case has a proper `RequestID`, and not `null`.