### PR TITLE
Use `private` fields for `NativeProvider` class

### DIFF
--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -19,10 +19,10 @@ const isWin = process.platform === 'win32';
 const debug = createDebug('@zeit/fun:providers/native');
 
 export default class NativeProvider implements Provider {
-	pool: Pool<ChildProcess>;
-	lambda: Lambda;
-	params: LambdaParams;
-	runtimeApis: WeakMap<ChildProcess, RuntimeServer>;
+	private pool: Pool<ChildProcess>;
+	private lambda: Lambda;
+	private params: LambdaParams;
+	private runtimeApis: WeakMap<ChildProcess, RuntimeServer>;
 
 	constructor(fn: Lambda, params: LambdaParams) {
 		const factory = {


### PR DESCRIPTION
Doing this alters the generated TypeScript declaration file to not import the `generic-pool` type declarations, which are a dev dependency.

This is useful for downstream consumers that compile with `tsc` (and avoids us having to move the `@types/generic-pool` module from `devDependencies` into `dependencies`).