### PR TITLE
Use the `tree-kill` module to shut down lambda functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "stat-mode": "0.3.0",
     "stream-to-promise": "2.2.0",
     "tar": "4.4.8",
+    "tree-kill": "1.2.1",
     "uid-promise": "1.0.0",
     "uuid": "3.3.2",
     "xdg-app-paths": "5.1.0",

--- a/src/providers/native/index.ts
+++ b/src/providers/native/index.ts
@@ -1,8 +1,10 @@
 import ms from 'ms';
 import uuid from 'uuid/v4';
 import createDebug from 'debug';
+import { promisify } from 'util';
 import { AddressInfo } from 'net';
 import listen from 'async-listen';
+import _treeKill from 'tree-kill';
 import { Pool, createPool } from 'generic-pool';
 import { delimiter, basename, join, resolve } from 'path';
 import { ChildProcess, spawn } from 'child_process';
@@ -17,6 +19,7 @@ import {
 
 const isWin = process.platform === 'win32';
 const debug = createDebug('@zeit/fun:providers/native');
+const treeKill = promisify(_treeKill);
 
 export default class NativeProvider implements Provider {
 	private pool: Pool<ChildProcess>;
@@ -150,7 +153,7 @@ export default class NativeProvider implements Provider {
 			this.unfreezeProcess(proc);
 
 			debug('Stopping process %o', proc.pid);
-			process.kill(proc.pid, 'SIGTERM');
+			await treeKill(proc.pid);
 		} catch (err) {
 			// ESRCH means that the process ID no longer exists, which is fine
 			// in this case since we're shutting down the process anyways

--- a/yarn.lock
+++ b/yarn.lock
@@ -3482,6 +3482,11 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
+tree-kill@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.1.tgz#5398f374e2f292b9dcc7b2e71e30a5c3bb6c743a"
+  integrity sha512-4hjqbObwlh2dLyW4tcz0Ymw0ggoaVDMveUB9w8kFSQScdRLo0gxO9J7WFcUBo+W3C1TLdFIEwNOWebgZZ0RH9Q==
+
 trim-newlines@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"


### PR DESCRIPTION
In the past, it has been witnessed that `bootstrap` child processes remain alive even after `fn.destroy()` is invoked. The circumstances for when/why this happens is uncertain at this time, however we are using `tree-kill` in Now CLI as well to handle killing sub-tree child processes that builders create.