### PR TITLE
[go1.x] Set `client.Timeout` to 0 for infinite

### DIFF
--- a/src/runtimes/go1.x/bootstrap.go
+++ b/src/runtimes/go1.x/bootstrap.go
@@ -230,7 +230,7 @@ func (mc *MockLambdaContext) ProcessEvents() {
 		req.Header.Set("Content-Type", "application/json")
 
 		client := &http.Client{}
-		client.Timeout = time.Second * 1
+		client.Timeout = 0
 		_, err = client.Do(req)
 		if err != nil {
 			log.Fatal(fmt.Errorf("Error sending response: %s", err))


### PR DESCRIPTION
Possibly a fix for https://github.com/zeit/now/issues/3323.

Unfortunately, I can't think of a good way to test for this behavior.