### PR TITLE
Fix bootstrap.go on Windows

### DIFF
--- a/src/runtimes/go1.x/bootstrap.go
+++ b/src/runtimes/go1.x/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	"os/signal"
 	"path"
 	"reflect"
+	"runtime"
 	"strconv"
 	"syscall"
 	"time"
@@ -83,7 +84,10 @@ func main() {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if runtime.GOOS != "windows" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	}
 
 	if err = cmd.Start(); err != nil {
 		defer abortRequest(mockContext, err)


### PR DESCRIPTION
This line is causing the following error on Windows:

```
unknown field 'Setpgid' in struct literal of type syscall.SysProcAttr
```