### PR TITLE
Fix filename for Go bootstrap on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "yauzl-promise": "2.1.3"
   },
   "devDependencies": {
+    "@types/fs-extra": "8.0.1",
     "@types/generic-pool": "3.1.9",
     "@types/node": "10.12.29",
     "@types/node-fetch": "2.5.0",

--- a/src/runtimes/go1.x/bootstrap.go
+++ b/src/runtimes/go1.x/bootstrap.go
@@ -21,7 +21,6 @@ import (
 	"os/signal"
 	"path"
 	"reflect"
-	"runtime"
 	"strconv"
 	"syscall"
 	"time"

--- a/src/runtimes/go1.x/bootstrap.go
+++ b/src/runtimes/go1.x/bootstrap.go
@@ -84,10 +84,7 @@ func main() {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-
-	if runtime.GOOS != "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
 	if err = cmd.Start(); err != nil {
 		defer abortRequest(mockContext, err)

--- a/src/runtimes/go1.x/bootstrap.ts
+++ b/src/runtimes/go1.x/bootstrap.ts
@@ -1,5 +1,7 @@
 import { join } from 'path';
 import { spawn } from 'child_process';
+import { getOutputFile } from './filename';
 
-const bootstrap = join(__dirname, 'bootstrap');
+const out = getOutputFile();
+const bootstrap = join(__dirname, out);
 spawn(bootstrap, [], { stdio: 'inherit' });

--- a/src/runtimes/go1.x/filename.ts
+++ b/src/runtimes/go1.x/filename.ts
@@ -1,0 +1,4 @@
+export function getOutputFile() {
+	const ext = process.platform === 'win32' ? '.exe' : '';
+	return `bootstrap${ext}`;
+}

--- a/src/runtimes/go1.x/index.ts
+++ b/src/runtimes/go1.x/index.ts
@@ -2,7 +2,8 @@ import { join } from 'path';
 import execa from 'execa';
 import createDebug from 'debug';
 import { Runtime } from '../../types';
-import { copyFile, mkdirp, remove } from 'fs-extra';
+import { readFile, writeFile, mkdirp, remove } from 'fs-extra';
+import { getOutputFile } from './filename';
 
 const debug = createDebug('@zeit/fun:runtimes/go1.x');
 
@@ -15,17 +16,28 @@ function _go(opts) {
 
 export async function init({ cacheDir }: Runtime): Promise<void> {
 	const source = join(cacheDir, 'bootstrap.go');
+	const out = getOutputFile();
+	let data = await readFile(source, 'utf8');
+
+	// Fix windows
+	if (process.platform === 'win32') {
+		debug('detected windows, so stripping Setpgid');
+		data = data
+			.split('\n')
+			.filter(line => !line.includes('Setpgid'))
+			.join('\n');
+	}
 
 	// Prepare a temporary `$GOPATH`
 	const GOPATH = join(cacheDir, 'go');
 
 	// The source code must reside in `$GOPATH/src` for `go get` to work
-	const bootstrapDir = join(GOPATH, 'src', 'bootstrap');
+	const bootstrapDir = join(GOPATH, 'src', out);
 	await mkdirp(bootstrapDir);
-	await copyFile(source, join(bootstrapDir, 'bootstrap.go'));
+	await writeFile(join(bootstrapDir, 'bootstrap.go'), data);
 
 	const go = _go({ cwd: bootstrapDir, env: { ...process.env, GOPATH } });
-	const bootstrap = join(cacheDir, 'bootstrap');
+	const bootstrap = join(cacheDir, out);
 	debug('Compiling Go runtime binary %o -> %o', source, bootstrap);
 	await go('get');
 	await go('build', '-o', bootstrap, 'bootstrap.go');

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,13 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/fs-extra@8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.0.1.tgz#a2378d6e7e8afea1564e44aafa2e207dadf77686"
+  integrity sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/generic-pool@3.1.9":
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/@types/generic-pool/-/generic-pool-3.1.9.tgz#cc82ee0d92561fce713f8f9a7b2380eda8a89dcb"


### PR DESCRIPTION
This PR adds a file extension `.exe` for windows when using the Go runtime.

It also filters out `Setpgid` which is not available on Windows.